### PR TITLE
Backup only *.sav files

### DIFF
--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -396,7 +396,7 @@ namespace RemnantSaveManager
                         }
                     }
                 }
-                foreach (string file in Directory.GetFiles(saveDirPath))
+                foreach (string file in Directory.GetFiles(saveDirPath, "*.sav"))
                     File.Copy(file, backupFolder + "\\" + System.IO.Path.GetFileName(file), true);
                 if (RemnantSave.ValidSaveFolder(backupFolder))
                 {


### PR DESCRIPTION
I saw that backup folder is over 3 gb, and has *.sav. *.bak & *.onl files
So, just copy *.sav files to reduce storage usage.